### PR TITLE
Add a button on the header to toggle between light and dark theme

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -2,24 +2,48 @@ import React from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 import { AiFillGithub } from 'react-icons/ai'
+import { BsSunFill, BsMoonStarsFill } from "react-icons/bs";
 
 const Header = () => {
+  const [theme, setTheme] = React.useState<string>("dark");
   return (
     <header className="py-6 flex justify-between">
       <Link href="..">
-        <h1 className="text-2xl md:text-4xl font-bold">restoreportraits.com</h1>
+      <h1 className="text-2xl md:text-4xl font-bold">restoreportraits.com</h1>
       </Link>
-      <div>
+      <div className="flex flex-row gap-8">
         <a
           href="https://github.com/bgwebagency/restoreportraits"
           target="_blank"
           rel="noreferrer"
+          className="hover:opacity-50 transition duration-150"
+          aria-label="Github"
         >
-          <AiFillGithub size={40} />
+          <AiFillGithub size={32} />
         </a>
+        <div className="w-[2.5em] hover:cursor-pointer">
+          {theme === "dark" ? (
+            <BsMoonStarsFill
+              size={26}
+              className="mt-1"
+              onClick={() => {
+                setTheme("light");
+                document.body.classList.toggle("dark");
+              }}
+            />
+          ) : (
+            <BsSunFill
+              size={32}
+              onClick={() => {
+                setTheme("dark");
+                document.body.classList.toggle("dark");
+              }}
+            />
+          )}
+        </div>
       </div>
     </header>
-  )
-}
+  );
+};
 
-export default Header
+export default Header;

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,14 +8,6 @@
   --background-end-rgb: 255, 255, 255;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
-}
-
 body {
   color: rgb(var(--foreground-rgb));
   background: linear-gradient(

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,3 +25,9 @@ body {
     )
     rgb(var(--background-start-rgb));
 }
+
+body.dark {
+  --foreground-rgb: 255, 255, 255;
+  --background-start-rgb: 0, 0, 0;
+  --background-end-rgb: 0, 0, 0;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,4 +15,5 @@ module.exports = greenhouse({
     },
   },
   plugins: [],
+  darkMode: "class",
 })


### PR DESCRIPTION
This is a proposed solution for [Issue#17](https://github.com/bgwebagency/restoreportraits.com/issues/17).
I added a toggle button on the header, similar to the button in the redesigner.io app. 